### PR TITLE
Fix missing check and defaults for primitive props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres poorly to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix missing check and defaults for primitive properties. Previously defaults were ignored for primitive values and the "reasonable defaults" were used instead for unset properties.
 
 ## [1.3.0] - 2020-06-17
 ### Added

--- a/src/test/java/fi/jubic/easyvalue/DefaultsTest.java
+++ b/src/test/java/fi/jubic/easyvalue/DefaultsTest.java
@@ -1,0 +1,90 @@
+package fi.jubic.easyvalue;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DefaultsTest {
+    @Test
+    void primitiveDefaultValueUsed() {
+        // Not used
+        PrimitiveClass obj1 = PrimitiveClass.builder()
+                .setBooleanValue(true)
+                .setIntegerValue(2)
+                .setFloatValue(3.0f)
+                .build();
+
+        assertTrue(obj1.getBooleanValue());
+        assertEquals(2, obj1.getIntegerValue());
+        assertEquals(3.0f, obj1.getFloatValue());
+
+        // Used
+        PrimitiveClass obj2 = PrimitiveClass.builder()
+                .setBooleanValue(true)
+                .setIntegerValue(2)
+                .build();
+
+        assertTrue(obj2.getBooleanValue());
+        assertEquals(2, obj2.getIntegerValue());
+        assertEquals(1.0f, obj2.getFloatValue());
+    }
+
+    @EasyValue
+    abstract static class PrimitiveClass {
+        abstract boolean getBooleanValue();
+
+        abstract int getIntegerValue();
+
+        abstract float getFloatValue();
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        static class Builder extends EasyValue_DefaultsTest_PrimitiveClass.Builder {
+            @Override
+            public Builder defaults(Builder builder) {
+                return builder.setFloatValue(1.0f);
+            }
+        }
+    }
+
+    @Test
+    void objectDefaultValueUsed() {
+        // Not used
+        MixedClass obj1 = MixedClass.builder()
+                .setIntegerValue(1)
+                .setStringValue("not default")
+                .build();
+
+        assertEquals(1, obj1.getIntegerValue());
+        assertEquals("not default", obj1.getStringValue());
+
+        // Used
+        MixedClass obj2 = MixedClass.builder()
+                .setIntegerValue(1)
+                .build();
+
+        assertEquals(1, obj2.getIntegerValue());
+        assertEquals("default", obj2.getStringValue());
+    }
+
+    @EasyValue
+    abstract static class MixedClass {
+        abstract int getIntegerValue();
+
+        abstract String getStringValue();
+
+        static Builder builder() {
+            return new Builder();
+        }
+
+        static class Builder extends EasyValue_DefaultsTest_MixedClass.Builder {
+            @Override
+            public Builder defaults(Builder builder) {
+                return builder.setStringValue("default");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Unset primitive properties were defaulting to "reasonable defaults"
provided by the platform. Neither runtime checks or explicit defaults
were working.

Boxing the primitives in the builder class allows applying the same
missing checks and explicit defaults to primitive properties while
maintaining the unboxed API on the value class.